### PR TITLE
adapt nodejs engine requirements to @strapi/strapi

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/NEDDL/strapi-v5-plugin-populate-deep"
   },
   "engines": {
-    "node": ">=14.19.1 <=20.x.x",
+    "node": ">=18.0.0 <=22.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
Strapi 5 never had NodeJS support below v18 and supports NodeJS up to v22:

- https://github.com/strapi/strapi/blob/v5.0.0/package.json#L160
- https://github.com/strapi/strapi/blob/v5.8.1/package.json#L163

Please release a new version