### PR TITLE
Add `pIgnore` so we can configure the ignore filter + fix ignore filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ The plugin allows you to deeply populate data in your Strapi queries with a new 
 2. Populate a request with the a custom depth
    `/api/articles?pLevel=10`
 
+3. Ignore some fields
+```js
+strapi.documents(model).findMany({
+  pLevel: 10,
+  pIgnore: ['updatedBy', 'createdBy', 'permissions', 'role', 'users'],
+});
+```
+
+
 ## Good to know
 
 - The default maximum depth is 5 levels deep.

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -6,6 +6,7 @@ module.exports = ({ strapi }) => {
   strapi.db.lifecycles.subscribe((event) => {
     if (event.action === "beforeFindMany" || event.action === "beforeFindOne") {
       const level = event.params?.pLevel;
+      const ignore =  event.params?.pIgnore || [];
 
       const defaultDepth =
         strapi
@@ -14,7 +15,7 @@ module.exports = ({ strapi }) => {
 
       if (level !== undefined) {
         const depth = level ?? defaultDepth;
-        const modelObject = getFullPopulateObject(event.model.uid, depth, []);
+        const modelObject = getFullPopulateObject(event.model.uid, depth, ignore);
         event.params.populate = modelObject.populate;
       }
     }

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -31,10 +31,10 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
     if (ignore?.includes(key)) continue;
     if (value) {
       if (value.type === "component") {
-        populate[key] = getFullPopulateObject(value.component, maxDepth - 1);
+        populate[key] = getFullPopulateObject(value.component, maxDepth - 1, ignore);
       } else if (value.type === "dynamiczone") {
         const dynamicPopulate = value.components.reduce((prev, cur) => {
-          const curPopulate = getFullPopulateObject(cur, maxDepth - 1);
+          const curPopulate = getFullPopulateObject(cur, maxDepth - 1, ignore);
           return merge(prev, {[cur]: curPopulate});
         }, {});
         populate[key] = isEmpty(dynamicPopulate) ? true : { on: dynamicPopulate };


### PR DESCRIPTION
👋 a small fix to improve the perf of the plugin and solve the crashing issue we can observe if `pLevel === 20` (_linked to circular refs inside `updatedBy`)

## Changes

- Add `pIgnore` key next to `pLevel` so anyone can tweak the list
- Always bind the list when we call `getFullPopulateObject`