### PR TITLE
fix: deep relations silently missing when same model appears in multiple schema paths

### DIFF
--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -54,10 +54,10 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
     if (ignore?.includes(key) || value.private === true) continue;
     if (value) {
       if (value.type === "component") {
-        populate[key] = getFullPopulateObject(value.component, maxDepth - 1, ignore);
+        populate[key] = getFullPopulateObject(value.component, maxDepth - 1, [...ignore]);
       } else if (value.type === "dynamiczone") {
         const dynamicPopulate = value.components.reduce((prev, cur) => {
-          const curPopulate = getFullPopulateObject(cur, maxDepth - 1, ignore);
+          const curPopulate = getFullPopulateObject(cur, maxDepth - 1, [...ignore]);
           return curPopulate === undefined ? prev : deepAssign(prev, { [cur]: curPopulate });
         }, {});
         populate[key] = isEmpty(dynamicPopulate) ? true : { on: dynamicPopulate };
@@ -66,7 +66,7 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
         const relationPopulate = getFullPopulateObject(
           value.target,
           key === "localizations" && maxDepth > 2 ? 1 : maxDepth - 1,
-          ignore
+          [...ignore]
         );
         if (relationPopulate) {
           populate[key] = relationPopulate;


### PR DESCRIPTION
##  Problem

Since v4.0.6, responses with pLevel ≥ 3 were missing data for relations at deeper levels. The regression was introduced in commit 467c251 ("propagate ignore list").

`getFullPopulateObject` mutates the ignore array by pushing the current model's collection name into it. Because the same array reference was passed to all recursive calls, any model visited in one branch of the tree was permanently
  added to the shared list — causing the relation pre-check to skip it in all sibling branches.

###  Example with pLevel=5:
  ModelA → ModelB → ModelD  ✅  _"modelD" added to shared ignore_
  ModelA → ModelC → ModelD  ❌  _skipped — "modelD" already in ignore_

##  Fix

Spread the array (`[...ignore]`) at every recursive call site so each branch receives its own copy. Ancestors in the current path are still present (preventing circular loops), but models visited in unrelated branches are not.

User-specified `pIgnore` entries are unaffected — they are in the array before any mutation, so they propagate into every copy.