### PR TITLE
fix: always populate localizations field regardless of ignore list

### DIFF
--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -62,14 +62,18 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
         }, {});
         populate[key] = isEmpty(dynamicPopulate) ? true : { on: dynamicPopulate };
       } else if (value.type === "relation") {
-        if (ignore?.includes(strapi.getModel(value.target).collectionName)) continue;
-        const relationPopulate = getFullPopulateObject(
-          value.target,
-          key === "localizations" && maxDepth > 2 ? 1 : maxDepth - 1,
-          [...ignore]
-        );
-        if (relationPopulate) {
-          populate[key] = relationPopulate;
+        if (key === "localizations") {
+          populate[key] = true;
+        } else {
+          if (ignore?.includes(strapi.getModel(value.target).collectionName)) continue;
+          const relationPopulate = getFullPopulateObject(
+            value.target,
+            maxDepth - 1,
+            [...ignore]
+          );
+          if (relationPopulate) {
+            populate[key] = relationPopulate;
+          }
         }
       } else if (value.type === "media") {
         populate[key] = true;


### PR DESCRIPTION
Self-referential relations (localizations) were being skipped because the model's collectionName was already in the ignore list by the time the localizations key was reached. Handle localizations before the ignore check and populate it shallowly (true) to avoid infinite recursion.

Closes #21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to populate-building logic, but it can increase query payloads by always including `localizations`.
> 
> **Overview**
> Fixes deep-populate generation so the `localizations` relation is **always populated** (set to shallow `true`) even when the target model is in the ignore list, preventing self-referential localization relations from being skipped and avoiding recursion depth handling specific to that field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22f168d5c83fef0627dbd68e5a4ee56d004a3e88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->