### PR TITLE
fix: populate self-referencing relations with basic fields instead of skipping

### DIFF
--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -65,7 +65,10 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
         if (key === "localizations") {
           populate[key] = true;
         } else {
-          if (ignore?.includes(strapi.getModel(value.target).collectionName)) continue;
+          if (ignore?.includes(strapi.getModel(value.target).collectionName)) {
+            populate[key] = true;
+            continue;
+          }
           const relationPopulate = getFullPopulateObject(
             value.target,
             maxDepth - 1,


### PR DESCRIPTION
## Problem

When a content type contains components with relations back to the same content type (self-referencing through a component), the relation data is completely missing from the API response.

### Example schema

```
sekce (content type)
  └── Komponenty (dynamic zone)
       └── Odkaz (component)
            └── sekce (relation → sekce)
```

Querying `GET /api/sekces?pLevel=6` returns `Odkaz` objects without the `sekce` field entirely.

### Root cause

In `server/helpers/index.js`, the root content type's collection name is added to the `ignore` list (line 49). When processing relations inside components, line 68 skips any relation whose target collection is in the ignore list:

```js
if (ignore?.includes(strapi.getModel(value.target).collectionName)) continue;
```

This `continue` completely omits the relation from the populate object, so Strapi never includes it in the response.

## Fix

Instead of skipping the relation entirely, set `populate[key] = true` so Strapi returns the relation's scalar fields without further deep nesting:

```diff
- if (ignore?.includes(strapi.getModel(value.target).collectionName)) continue;
+ if (ignore?.includes(strapi.getModel(value.target).collectionName)) {
+   populate[key] = true;
+   continue;
+ }
```

This prevents infinite recursion (no further depth is added) while still including the relation data (id, slug, etc.) in the response.

## Environment

- Strapi v5.40.0
- strapi-v5-plugin-populate-deep v4.3.2
- PostgreSQL

Fixes #24