### PR TITLE
Include duplicates in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ module.exports = ({ env }) => ({
   'strapi-v5-plugin-populate-deep': {
     config: {
       defaultDepth: 3, // default: 5
-    },
+      includeDuplicates: true, // default: false
+    }
   },
 });
 ```
@@ -71,6 +72,9 @@ module.exports = ({ env }) => ({
 - Increasing depth may result in longer response times — use `pIgnore` to offset this.
 - `plugin::upload.file` related field is always excluded to avoid bloated responses.
 - `admin::user` (creator fields) can be excluded via `skipCreatorFields` config:
+- The `includeDuplicates` flag controls wether a shared relation is included multiple times in the response. If items `a` and `b` both have a relation to `c`, then with `includeDuplicates: false` (the default), item `c` would only appear under `b` in the API response.
+
+# Contributions
 
 ```js
 module.exports = ({ env }) => ({

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -5,6 +5,9 @@ module.exports = ({ strapi }) => {
   const defaultDepth =
     strapi.plugin("strapi-v5-plugin-populate-deep")?.config("defaultDepth") ||
     5;
+  const defaultIncludeDuplicates =
+    strapi.plugin("strapi-v5-plugin-populate-deep")?.config("includeDuplicates") ||
+    false;
 
   strapi.db.lifecycles.subscribe((event) => {
     const { action, model, params } = event;
@@ -12,6 +15,7 @@ module.exports = ({ strapi }) => {
     if (!["beforeFindMany", "beforeFindOne"].includes(action)) return;
     if (!model.uid.startsWith("api::")) return;
 
+<<<<<<< HEAD
     const ctx = strapi.requestContext.get();
     if (!ctx?.request?.url?.startsWith("/api/")) return;
 
@@ -20,11 +24,34 @@ module.exports = ({ strapi }) => {
 
     const pIgnore = params?.pIgnore ?? ctx.query?.pIgnore ?? [];
     const ignore = typeof pIgnore === 'string' ? pIgnore.split(',').map(s => s.trim()) : Array.isArray(pIgnore) ? pIgnore : [pIgnore];
+    const includeDuplicates = params?.includeDuplicates ?? defaultIncludeDuplicates;
 
     const depth = pLevel ? parseInt(pLevel, 10) : defaultDepth;
-    const populateObj = getFullPopulateObject(model.uid, depth, ignore);
+    const populateObj = getFullPopulateObject(model.uid, depth, ignore, includeDuplicates);
     if (populateObj && populateObj !== true) {
       params.populate = populateObj.populate;
+||||||| parent of 1a11dbf (Include duplicates in response)
+      if (level !== undefined) {
+        const depth = level ?? defaultDepth;
+        const modelObject = getFullPopulateObject(event.model.uid, depth, []);
+        event.params.populate = modelObject.populate;
+      }
+=======
+      const defaultIncludeDuplicates =
+        strapi
+          .plugin("strapi-v5-plugin-populate-deep")
+          ?.config("includeDuplicates") || false;
+
+      if (level !== undefined) {
+        const depth = level ?? defaultDepth;
+        const includeDuplicates =
+          includeDuplicatesParam !== undefined
+            ? includeDuplicatesParam !== "false"
+            : defaultIncludeDuplicates;
+        const modelObject = getFullPopulateObject(event.model.uid, depth, [], includeDuplicates);
+        event.params.populate = modelObject.populate;
+      }
+>>>>>>> 1a11dbf (Include duplicates in response)
     }
   });
 };

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -33,7 +33,7 @@ const getModelPopulationAttributes = (model) => {
   return model.attributes;
 };
 
-const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
+const getFullPopulateObject = (modelUid, maxDepth = 20, ignore, includeDuplicates) => {
   if (maxDepth <= 1) {
     return true;
   }
@@ -51,7 +51,8 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
   for (const [key, value] of Object.entries(
     getModelPopulationAttributes(model)
   )) {
-    if (ignore?.includes(key) || value.private === true) continue;
+
+    if ((!includeDuplicates && ignore?.includes(key)) || value.private === true) continue;
     if (value) {
       if (value.type === "component") {
         populate[key] = getFullPopulateObject(value.component, maxDepth - 1, [...ignore]);
@@ -69,7 +70,8 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
           const relationPopulate = getFullPopulateObject(
             value.target,
             maxDepth - 1,
-            [...ignore]
+            [...ignore],
+            includeDuplicates
           );
           if (relationPopulate) {
             populate[key] = relationPopulate;


### PR DESCRIPTION
This change allows the API response to have a single item appear multiple times as a relation to other items. Previous functionality only added one copy of each item in the response even if multiple items linked to it.